### PR TITLE
Migrate to version `0.6.0` of the `fastly` crate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 /README.md @fastly/developer-relations
 /fastly.toml @fastly/developer-relations
 *.rs @fastly/ecp-sdk-sme-rust
-/Cargo.toml @fastly/ecp-sdk-sme
+/Cargo.toml @fastly/ecp-sdk-sme-rust

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 /README.md @fastly/developer-relations
 /fastly.toml @fastly/developer-relations
-*.rs @fastly/ecp-sdk-sme
+*.rs @fastly/ecp-sdk-sme-rust
 /Cargo.toml @fastly/ecp-sdk-sme

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        rust-toolchain: [1.46.0]
+        rust-toolchain: [1.49.0]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,17 +13,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
-name = "beacon-termination"
-version = "0.1.0"
-dependencies = [
- "chrono-wasi",
- "fastly",
- "ipnet",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,36 +32,34 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chrono"
-version = "0.4.13"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
-dependencies = [
- "num-integer",
- "num-traits",
- "serde",
-]
-
-[[package]]
-name = "chrono-wasi"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523c793565614ed99b4c7f25e01bb8cace0c04990b9036e89ec7047970f01594"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
  "libc",
- "mach",
  "num-integer",
  "num-traits",
- "redox_syscall",
  "serde",
- "wasi",
+ "time",
  "winapi",
 ]
 
 [[package]]
+name = "compute-starter-kit-rust-beacon-termination"
+version = "0.2.0"
+dependencies = [
+ "chrono",
+ "fastly",
+ "ipnet",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "fastly"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238ebcba2d40d5a60c5830e50a0d0e2afb58983254372ec9f403affa40e59b76"
+checksum = "b32333410ceb0499e2c98af856a47464231e44e78cbfc4a5c66592c1dd8bd07a"
 dependencies = [
  "anyhow",
  "bytes",
@@ -83,16 +70,19 @@ dependencies = [
  "http",
  "lazy_static",
  "log",
+ "mime",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "thiserror",
+ "url",
 ]
 
 [[package]]
 name = "fastly-macros"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9984ad9326e0e677e00ab5a996942ad6eacc9b085877bc078bad9b3119fd808"
+checksum = "9805cc40e0ce43131c09107bf833af402ab102ed2e0bdd1a7f4d9b8789138229"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -101,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "fastly-shared"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533b3809fad597f3c6e602b7b69d1bb0ca9028a06725b1a1eabc85742c7fa780"
+checksum = "a31e6b7bc3eae372a3538281a7c38af84bdc15298cfa71badb7eb9f5cb487ae8"
 dependencies = [
  "bitflags",
  "http",
@@ -112,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "fastly-sys"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70249b5ad5aba30047e6f75d20c5634cca0972b686170bb13533b20c52a01b2b"
+checksum = "6b95e92b98ef5ea2cef58bde3f3ca41c4fa478172ac66e2d491923765f2b8690"
 dependencies = [
  "fastly-shared",
 ]
@@ -126,6 +116,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "http"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +134,17 @@ dependencies = [
  "bytes",
  "fnv",
  "itoa",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -170,13 +181,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "mach"
-version = "0.3.2"
+name = "matches"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
-dependencies = [
- "libc",
-]
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "num-integer"
@@ -198,10 +212,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.19"
+name = "percent-encoding"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
@@ -216,12 +236,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,18 +243,18 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "serde"
-version = "1.0.114"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
+checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.114"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
+checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -249,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.57"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
  "itoa",
  "ryu",
@@ -259,10 +273,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "1.0.36"
+name = "serde_urlencoded"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cdb98bcb1f9d81d07b536179c269ea15999b5d14ea958196413869445bb5250"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -290,16 +316,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi",
+ "winapi",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+dependencies = [
+ "matches",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
+name = "url"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "compute-starter-kit-rust-beacon-termination"
-version = "0.1.0"
-authors = ["Dora Militaru <dmilitaru@fastly.com>"]
+version = "0.2.0"
+authors = []
 edition = "2018"
 
 [profile.release]
 debug = true
 
 [dependencies]
-chrono-wasi = { version = "^0.4.10", features = ["serde"] }
-fastly = "^0.4.0"
-ipnet = "2.1.0"
-serde = { version = "1.0.104", features = ["derive"] }
-serde_json = "1.0.44"
+chrono = "0.4.19"
+fastly = "0.6.0"
+ipnet = "2.3.0"
+serde = { version = "1.0.123", features = ["derive"] }
+serde_json = "1.0.61"

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # Compute@Edge starter kit for beacon termination
 
-A Rust based Compute@Edge starter kit for a beacon reporting endpoint.
+Capture beacon data from the browser, divert beacon request payloads to a log endpoint, and avoid putting load on your own infrastructure.
 
-**For more details about this and other starter kits for Compute@Edge, see the [Fastly developer hub](https://developer.fastly.com/solutions/starters)**.
+**For more details about this and other starter kits for Compute@Edge, see the [Fastly Developer Hub](https://developer.fastly.com/solutions/starters/)**.
 
 ## What are beacons?
 
 Beacons are HTTP requests, usually `POST`s, sent from a web browser to record some analytics data. Browsers offer native support for beacons via the `navigator.sendBeacon` method, and via the [Reporting API](https://developers.google.com/web/updates/2018/09/reportingapi) for out-of-band reports on browser-generated warnings like CSP and feature policy violations, deprecations, browser interventions, and network errors. Native apps will also often send beacon data back to base.
 
-**For an in-depth guide to beacon termination using VCL, see the [Beacon Termination tutorial](https://developer.fastly.com/solutions/tutorials/beacon-termination) on Fastly's developer hub**.
+**For an in-depth guide to beacon termination using VCL, see the [Beacon Termination tutorial](https://developer.fastly.com/solutions/tutorials/beacon-termination/)**.
 
 ## Features
 
-* Exposes a `POST /reports` endpoint to receive beacon reports (in batches);
-* Deserializes individual reports from JSON to Rust data structures, with optional type-checking (see [Payload examples](#payload-examples));
-* Enriches the data with information available at the edge, e.g. by adding geo data;
-* Sends reports to a logging endpoint as individual JSON lines;
-    N.B.: Depending on which [logging endpoint type](https://developer.fastly.com/reference/api/logging/) is chosen, these lines may be batched.
-* Responds with a synthetic 204.
+- Exposes a `POST /reports` endpoint to receive beacon reports (in batches)
+- Deserializes individual reports from JSON to Rust data structures, with optional type-checking (see [Payload examples](#payload-examples))
+- Enriches the data with information available at the edge, e.g. by adding geo data
+- Sends reports to a logging endpoint as individual JSON lines
+  N.B.: Depending on which [logging endpoint type](https://developer.fastly.com/reference/api/logging/) is chosen, these lines may be batched.
+- Responds with a synthetic 204
 
 ### Payload examples
 
@@ -25,23 +25,22 @@ This starter kit allows an individual report to be any valid JSON value.
 
 For optional type-checking, it also includes the data structures for some common report payloads. These structures can be imported from modules following the `example_...` naming convention:
 
-
-* CSP Violations
-    ```
-    mod example_csp_violation;
-    use crate::example_csp_violation::ReportBody;
-    ```
-* Network Errors
-    ```
-    mod example_network_error_log;
-    use crate::example_network_error_log::ReportBody;
-    ```
-* Core Web Vitals
-    ```
-    mod example_core_web_vital;
-    use crate::example_core_web_vital::ReportBody;
-    ```
-    Tip: Use the [web-vitals JavaScript library](https://web.dev/vitals/) to measure all the Core Web Vitals.
+- CSP Violations
+  ```
+  mod example_csp_violation;
+  use crate::example_csp_violation::ReportBody;
+  ```
+- Network Errors
+  ```
+  mod example_network_error_log;
+  use crate::example_network_error_log::ReportBody;
+  ```
+- Core Web Vitals
+  ```
+  mod example_core_web_vital;
+  use crate::example_core_web_vital::ReportBody;
+  ```
+  Tip: Use the [web-vitals JavaScript library](https://web.dev/vitals/) to measure all the Core Web Vitals.
 
 ## Requirements
 

--- a/fastly.toml
+++ b/fastly.toml
@@ -1,5 +1,5 @@
-version = 1
-name = "Compute@Edge starter kit for beacon termination"
-description = "Capture beacon data from the browser, divert beacon request payloads to a log endpoint, and avoid putting load on your own infrastructure"
-authors = ["Dora Militaru <dmilitaru@fastly.com>"]
+manifest_version = "0.1.0"
+name = "Beacon termination"
+description = "Capture beacon data from the browser, divert beacon request payloads to a log endpoint, and avoid putting load on your own infrastructure."
+authors = ["<oss@fastly.com>"]
 language = "rust"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.46.0"
+channel = "1.49.0"
 targets = [ "wasm32-wasi" ]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,3 @@
-1.46.0
+[toolchain]
+channel = "1.46.0"
+targets = [ "wasm32-wasi" ]

--- a/src/example_core_web_vital.rs
+++ b/src/example_core_web_vital.rs
@@ -1,4 +1,3 @@
-//! Core Web Vital report example.
 use serde::{Deserialize, Serialize};
 use serde_json::value::Value;
 

--- a/src/example_csp_violation.rs
+++ b/src/example_csp_violation.rs
@@ -1,4 +1,3 @@
-//! CSP violation report example.
 use serde::{Deserialize, Serialize};
 
 /// `ReportBody` models the body of a CSP report object.

--- a/src/example_network_error_log.rs
+++ b/src/example_network_error_log.rs
@@ -1,4 +1,3 @@
-//! Network Error Logging report example.
 use serde::{Deserialize, Serialize};
 
 /// `ReportBody` models the body of a Network Error Logging (NEL) report.

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,6 @@ impl LogLine {
 /// headers required for the beacon preflight request.
 pub fn generate_empty_204_response() -> Response {
     Response::from_status(StatusCode::NO_CONTENT)
-        .with_header(header::CONTENT_TYPE, "application/json")
         .with_header(
             header::CACHE_CONTROL,
             "no-cache, no-store, max-age=0, must-revalidate",

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ fn main(req: Request) -> Result<Response, Error> {
             Ok(generate_empty_204_response())
         }
         // For all other requests return a 404.
-        _ => Ok(Response::from_body("Not found").with_status(StatusCode::NOT_FOUND)),
+        _ => Ok(Response::from_status(StatusCode::NOT_FOUND).with_body_str("Not found\n")),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ fn handle_reports(mut req: Request) -> Result<(), Error> {
     // Parse the beacon reports from the request JSON body using serde_json.
     // If successful, bind the reports to the `reports` variable,
     // optionally transform and typecheck the payload, and log.
-    let reports = req.take_body_json::<Vec<Report<ReportBody>>>().unwrap();
+    let reports = req.take_body_json::<Vec<Report<ReportBody>>>()?;
 
     // Extract information about the client from the downstream request,
     // such as the User-Agent and IP address.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,4 @@
-//! Compute@Edge starter kit for beacon termination
-//!
-//! A Compute@Edge service which exposes a HTTP reporting endpoint for beacon termination.
-
+//! Compute@Edge starter kit for beacon termination.
 mod client_data;
 mod example_core_web_vital;
 mod example_csp_violation;
@@ -13,7 +10,7 @@ use crate::report::Report;
 use chrono::Utc;
 use fastly::http::{header, Method, StatusCode};
 use fastly::log::Endpoint;
-use fastly::{downstream_client_ip_addr, Body, Error, Request, Response, ResponseExt};
+use fastly::{Error, Request, Response};
 use serde::{Deserialize, Serialize};
 
 // This line allows any valid JSON value in the report body.
@@ -29,21 +26,19 @@ use serde_json::value::Value as ReportBody;
 /// and passes it to any matching request handlers before returning a `Response`
 /// back downstream.
 #[fastly::main]
-fn main(req: Request<Body>) -> Result<Response<Body>, Error> {
+fn main(req: Request) -> Result<Response, Error> {
     // Pattern match on the request method and path.
-    match (req.method(), req.uri().path()) {
-        // If a CORS preflight OPTIONS request return a 204 no content.
-        (&Method::OPTIONS, "/report") => generate_no_content_response(),
-        // If a POST request pass to the `handler_reports` request handler.
+    match (req.get_method(), req.get_path()) {
+        // For a CORS preflight OPTIONS request, return an empty 204 response.
+        (&Method::OPTIONS, "/report") => Ok(generate_empty_204_response()),
+        // Pass a POST request to the `handler_reports` request handler.
         (&Method::POST, "/report") => {
             let _ = handle_reports(req);
-            // Return an empty 204 No Content response to the downstream client.
-            generate_no_content_response()
+            // Return an empty 204 response to the downstream client.
+            Ok(generate_empty_204_response())
         }
-        // For all other requests return a 404 not found.
-        _ => Ok(Response::builder()
-            .status(StatusCode::NOT_FOUND)
-            .body(Body::from("Not found"))?),
+        // For all other requests return a 404.
+        _ => Ok(Response::from_body("Not found").with_status(StatusCode::NOT_FOUND)),
     }
 }
 
@@ -52,22 +47,16 @@ fn main(req: Request<Body>) -> Result<Response<Body>, Error> {
 /// It attempts to extract the beacon reports from the POST request body and maps
 /// over each report adding additional information before emitting a log line
 /// to the `reports` logging endpoint if valid.
-fn handle_reports(req: Request<Body>) -> Result<(), Error> {
-    let (parts, body) = req.into_parts();
-
+fn handle_reports(mut req: Request) -> Result<(), Error> {
     // Parse the beacon reports from the request JSON body using serde_json.
     // If successful, bind the reports to the `reports` variable,
     // optionally transform and typecheck the payload, and log.
-    let reports = serde_json::from_reader::<Body, Vec<Report<ReportBody>>>(body)?;
+    let reports = req.take_body_json::<Vec<Report<ReportBody>>>().unwrap();
 
     // Extract information about the client from the downstream request,
     // such as the User-Agent and IP address.
-    let client_user_agent = parts
-        .headers
-        .get(header::USER_AGENT)
-        .and_then(|header| header.to_str().ok())
-        .unwrap_or("");
-    let client_ip = downstream_client_ip_addr().expect("should have client IP");
+    let client_user_agent = req.get_header_str(header::USER_AGENT).unwrap_or("");
+    let client_ip = req.get_client_ip_addr().expect("should have client IP");
 
     // Construct a new `ClientData` structure from the IP and User Agent.
     let client_data = ClientData::new(client_ip, client_user_agent)?;
@@ -131,17 +120,15 @@ impl LogLine {
 /// Generates a response with a 204 status code, ensures the response is
 /// non-cacheable via cache-control header directives and adds appropriate CORS
 /// headers required for the beacon preflight request.
-pub fn generate_no_content_response() -> Result<Response<Body>, Error> {
-    Ok(Response::builder()
-        .status(StatusCode::NO_CONTENT)
-        .header(header::CONTENT_TYPE, "application/json")
-        .header(
+pub fn generate_empty_204_response() -> Response {
+    Response::from_status(StatusCode::NO_CONTENT)
+        .with_header(header::CONTENT_TYPE, "application/json")
+        .with_header(
             header::CACHE_CONTROL,
             "no-cache, no-store, max-age=0, must-revalidate",
         )
-        .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
-        .header(header::ACCESS_CONTROL_ALLOW_HEADERS, header::CONTENT_TYPE)
-        .header(header::ACCESS_CONTROL_ALLOW_METHODS, "POST, OPTIONS")
-        .header(header::CONNECTION, "keep-alive")
-        .body(Body::new())?)
+        .with_header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+        .with_header(header::ACCESS_CONTROL_ALLOW_HEADERS, header::CONTENT_TYPE)
+        .with_header(header::ACCESS_CONTROL_ALLOW_METHODS, "POST, OPTIONS")
+        .with_header(header::CONNECTION, "keep-alive")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ fn main(req: Request) -> Result<Response, Error> {
         (&Method::OPTIONS, "/report") => Ok(generate_empty_204_response()),
         // Pass a POST request to the `handler_reports` request handler.
         (&Method::POST, "/report") => {
-            let _ = handle_reports(req);
+            let _ = handle_reports(req)?;
             // Return an empty 204 response to the downstream client.
             Ok(generate_empty_204_response())
         }

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,4 +1,3 @@
-//! Generic JSON report example.
 use serde::{Deserialize, Serialize};
 
 /// `Report` models a beacon payload.


### PR DESCRIPTION
Upgrades the default Compute@Edge starter kit for rust to version `0.6.0` of the `fastly` crate, along with:
- a more descriptive version of the rust-toolchain file
- minor copyedits for consistency with Developer Hub and other starter kits
- linting
- adding Rust SME team as codeowners