### PR TITLE
use latest `manifest_version` interface

### DIFF
--- a/fastly.toml
+++ b/fastly.toml
@@ -1,4 +1,4 @@
-manifest_version = 1
+manifest_version = 2
 name = "Beacon termination"
 description = "Capture beacon data from the browser, divert beacon request payloads to a log endpoint, and avoid putting load on your own infrastructure."
 authors = ["<oss@fastly.com>"]


### PR DESCRIPTION
The https://developer.fastly.com/reference/compute/fastly-toml/ reference is being updated with a breaking change to the `[setup]` configuration. This change will result in a bump in `manifest_version` to version `2`. 

The next CLI release (`v0.39.3`) will only support manifests with a version number of `2`. So it's important that we coordinate the update to the fastly.toml documentation, and also each of the starter kits that the CLI references, so they specify their manifest_version as being version `2` (hence this PR).