### PR TITLE
Rename `.cargo/config` to `.cargo/config.toml` to support latest stable Cargo

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,0 @@
-[target.wasm32-wasi]
-rustflags = ["-C", "debuginfo=2"]
-
-[build]
-target = "wasm32-wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 debug = true
 
 [dependencies]
-chrono = { version = "^0.4.31", default-features = false, features = ["clock"] }
-fastly = "0.9.0"
+chrono = { version = "^0.4.38", default-features = false, features = ["clock"] }
+fastly = "0.10.0"
 ipnet = "^2.9.0"
-serde = { version = "^1.0.189", features = ["derive"] }
-serde_json = "^1.0.107"
+serde = { version = "^1.0.200", features = ["derive"] }
+serde_json = "^1.0.116"


### PR DESCRIPTION
Based on https://github.com/fastly/compute-starter-kit-rust-default/pull/70