### PR TITLE
Upgrade to Compute Rust SDK 0.11.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ debug = true
 
 [dependencies]
 chrono = { version = "^0.4.31", default-features = false, features = ["clock"] }
-fastly = "0.9.0"
+fastly = "0.11.2"
 ipnet = "^2.9.0"
 serde = { version = "^1.0.189", features = ["derive"] }
 serde_json = "^1.0.107"


### PR DESCRIPTION
Switched from using the deprecated 'uap_parse' function to using 'device_detection::lookup'.